### PR TITLE
Fix LLVM data layout for recent releases of Rust

### DIFF
--- a/thumbv6m-none-eabi.json
+++ b/thumbv6m-none-eabi.json
@@ -1,7 +1,7 @@
 {
     "arch": "arm",
     "cpu": "cortex-m0",
-    "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
     "disable-redzone": true,
     "executables": true,
     "llvm-target": "thumbv6m-none-eabi",


### PR DESCRIPTION
At some point they updated LLVM, and it broke the build. This should allow this repo to build again.
